### PR TITLE
fallback to est model if no sim model provided

### DIFF
--- a/man/sample_and_adjust_by_dose.Rd
+++ b/man/sample_and_adjust_by_dose.Rd
@@ -10,11 +10,12 @@ sample_and_adjust_by_dose(
   regimen,
   covariates = NULL,
   pars_true_i,
-  sim_model,
   est_model,
   est_parameters,
   est_omega,
   est_ruv,
+  sim_model = NULL,
+  sim_ruv = NULL,
   dose_grid = NULL,
   target = list(type = "conc", value = 10),
   target_time = 24,
@@ -33,8 +34,6 @@ time of first dose.}
 
 \item{pars_true_i}{PK parameters for the individual. See \code{generate_iiv}.}
 
-\item{sim_model}{model to use for simulating "true" patient response.}
-
 \item{est_model}{model to use for estimating patient response.}
 
 \item{est_parameters}{parameters for \code{est_model}.}
@@ -43,6 +42,12 @@ time of first dose.}
 
 \item{est_ruv}{residual variability for \code{est_model}. Named list for
 proportional (\code{prop}) and additive (\code{add}) error.}
+
+\item{sim_model}{model to use for simulating "true" patient response. If
+NULL, uses \code{est_model}.}
+
+\item{sim_ruv}{residual variability for \code{sim_model}. Named list for
+proportional (\code{prop}) and additive (\code{add}) error. If NULL, uses \code{est_ruv}.}
 
 \item{dose_grid}{vector specifying doses to use as test grid for dose
 finding, Example: seq(from = 50, to = 500, by = (500 - 50) / 10 ). If
@@ -66,7 +71,10 @@ that is, both with and without residual variability).
 Doses are iteratively adjusted for the specified dose numbers. Estimation is
 performed by MAP Bayesian estimation, and simulation is used to identify the
 dose most likely to reach the specified target. See \code{dose_grid_search} for
-dose-finding logic.
+dose-finding logic. Optionally, disparate models can be used for simulation
+and estimation, to allow for intentional model misspecification. Covariates
+supplied must support both models. True patient parameters (\code{pars_true_i})
+must match the model used for simulation.
 }
 \details{
 Trial design or MIPD protocol can vary considerably in complexity. This

--- a/tests/testthat/test-sample_and_adjust.R
+++ b/tests/testthat/test-sample_and_adjust.R
@@ -1,6 +1,7 @@
-suppressMessages( ## avoid message "the following objects are masked from ..."
+suppressMessages({ ## avoid message "the following objects are masked from ..."
   require("pk1cmtivauc", character.only = TRUE)
-)
+  require("pkbusulfanmccune", character.only = TRUE)
+})
 mod <- get("model", asNamespace("pk1cmtivauc"))()
 par <- list(CL = 1, V = 10)
 omega <- c(0.1, 0.05, 0.1)
@@ -101,6 +102,114 @@ test_that("Supplying true pars as list also works", {
   )
   # allow up to 5% error from goal of 10 mg/L
   expect_true(abs((tmp$y - 10)/10) < 0.05)
+})
+
+test_that("Can supply just one model (for both est and sim)", {
+
+  set.seed(1)
+  out1 <- sample_and_adjust_by_dose( #specify est and sim model
+    adjust_at_dose = c(2, 4),
+    tdm_times = c(12, 64),
+    regimen = regimen,
+    pars_true_i = list(CL = 1.5, V = 15),
+    sim_model = mod,
+    sim_ruv = list(prop = 0.1, add = 1),
+    est_model = mod,
+    est_parameters = par,
+    est_omega = omega,
+    est_ruv = list(prop = 0.1, add = 1),
+    target_time = 4 * 24,
+    target = list(type = "conc", value = 10)
+  )
+  set.seed(1)
+  out2 <- sample_and_adjust_by_dose( # specify just est_model
+    adjust_at_dose = c(2, 4),
+    tdm_times = c(12, 64),
+    regimen = regimen,
+    pars_true_i = list(CL = 1.5, V = 15),
+    est_model = mod,
+    est_parameters = par,
+    est_omega = omega,
+    est_ruv = list(prop = 0.1, add = 1),
+    target_time = 4 * 24,
+    target = list(type = "conc", value = 10)
+  )
+
+  # expected structure
+  expect_identical(out1, out2)
+})
+
+test_that("Can use separate models for sim and est", {
+
+  regimen <- PKPDsim::new_regimen(
+    amt = 200,
+    n = 4,
+    interval = 24
+  )
+
+  mod2 <- pkbusulfanmccune::model()
+  par2 <- pkbusulfanmccune::parameters()
+
+  covs <- list(
+    AGE = PKPDsim::new_covariate(12),
+    WT = PKPDsim::new_covariate(40),
+    HT = PKPDsim::new_covariate(120),
+    SEX = PKPDsim::new_covariate(1),
+    T_CL_EFF = PKPDsim::new_covariate(0)
+  )
+
+  out <- sample_and_adjust_by_dose( # est and sim model are different
+    adjust_at_dose = c(2, 4),
+    tdm_times = c(3, 5, 8, 12, 51, 53, 56, 60),
+    regimen = regimen,
+    covariates = covs,
+    pars_true_i = par2,
+    sim_model = mod2,
+    sim_ruv = list(prop = 0.05, add = 1),
+    est_model = mod,
+    est_parameters = par,
+    est_omega = omega,
+    est_ruv = list(prop = 0.1, add = 1),
+    target_time = 192,
+    target = list(type = "cum_auc", value = 90000)
+  )
+
+
+  # expected structure
+  expect_true(inherits(out, "list"))
+  expect_true(
+    all(c("final_regimen", "final_estimates", "tdms") %in% names(out))
+  )
+
+  # expected doses are changed
+  final_doses <- out$final_regimen
+  # first is unchanged
+  expect_equal(final_doses$dose_amts[1], regimen$dose_amts[1])
+  # 2nd and 3rd are the same
+  expect_equal(final_doses$dose_amts[2], final_doses$dose_amts[3])
+  # 4th is different from others
+  expect_true(final_doses$dose_amts[3] != final_doses$dose_amts[4])
+
+  # expected tdm sampling structure
+  tdms <- out$tdms
+  expect_equal(nrow(tdms), 8) # tdm_times is length 8, 4 per dosing interval
+  expect_false(any(tdms$true_y == tdms$y))
+
+  # estimates correspond to estimation parameters and not simulation parameters
+  ests <- out$final_estimates
+  expect_equal(sort(names(ests)), sort(names(par)))
+
+  # reasonable output
+  tmp <- PKPDsim::sim(
+    mod,
+    parameters = ests, # best guess
+    regimen = final_doses, # final regimen
+    t_obs = 192,
+    only_obs = FALSE
+  )
+  # allow up to 5% error from goal of 90,000 mg-h/L
+  cum_auc <- tmp$y[tmp$comp == 2]
+  expect_true(abs((cum_auc - 90e3)/90e3) < 0.05)
 })
 
 test_that("errors if dose update includes dose 1", {


### PR DESCRIPTION
Feedback from other end users suggested that requiring simulation model and estimation model to always be treated separately was too confusing/onerous. This PR updates the `sample_and_adjust` function to fall back to the estimation model if a separate simulation model is not provided.