### PR TITLE
Model-based initial regimen for trough targets

### DIFF
--- a/R/model_based_starting_dose.R
+++ b/R/model_based_starting_dose.R
@@ -16,7 +16,6 @@ model_based_starting_dose <- function(
     cov_mapping,
     ...
 ) {
-  #browser()
   ## Parsing and checking design specs
   reg_md <- design$initial_regimen$regimen
   interval <- reg_md$interval
@@ -41,6 +40,7 @@ model_based_starting_dose <- function(
     t_aim <- (scheme$at-1) * 24
     n_doses <- which.min(abs(seq(0, 100*interval, interval) - t_aim))
   }
+  # for trough-based target need to add 1 so that we have the end of interval
   if (scheme$base == "cmin") n_doses <- n_doses + 1
 
   ## create a dummy regimen as input to dose_grid_search:

--- a/R/model_based_starting_dose.R
+++ b/R/model_based_starting_dose.R
@@ -16,7 +16,7 @@ model_based_starting_dose <- function(
     cov_mapping,
     ...
 ) {
-
+  #browser()
   ## Parsing and checking design specs
   reg_md <- design$initial_regimen$regimen
   interval <- reg_md$interval
@@ -41,6 +41,7 @@ model_based_starting_dose <- function(
     t_aim <- (scheme$at-1) * 24
     n_doses <- which.min(abs(seq(0, 100*interval, interval) - t_aim))
   }
+  if (scheme$base == "cmin") n_doses <- n_doses + 1
 
   ## create a dummy regimen as input to dose_grid_search:
   reg <- PKPDsim::new_regimen(


### PR DESCRIPTION
This draft PR is one proposed approach to allow model-based starting doses when the target is a trough.

Due to the way we anchor sampling times for troughs here:

https://github.com/InsightRX/mipdtrial/blob/main/R/get_sampling_times_from_schema.R#L44-L45

We need to have one more dose than otherwise anticipated. One option is to add an additional dose. This works fine for continuous dosing modules (i.e., the expected time/day will be "sampled" to determine target attainment) however it won't work for fixed dosing (busulfan, etc). On the other hand, fixed dosing never targets a trough concentration, since that doesn't really make sense.

Alternatively, we could do some magic with the `get_sampling_times_from_scheme` function, but I think the logic would be a little more complicated?

```r
  else if(row$base %in% c("trough", "cmin")) {
    # take associated dosing interval if possible, otherwise take prev dosing interval
    # otherwise assume 24
    if (length(regimen$dose_times) > dose_anchor) {
      intv <- diff(regimen$dose_times[dose_anchor:(dose_anchor+1)] 
    } else if (dose_anchor > 1) {
      intv <- diff(regimen$dose_times[(dose_anchor-1):dose_anchor] 
    } else {
      intv <- 24
    }
    t_anchor <- regimen$dose_times[dose_anchor] + intv
  }
```