### PR TITLE
RXR-2195: allow auc12 as target; set seed for each patient start

### DIFF
--- a/R/create_target_design.R
+++ b/R/create_target_design.R
@@ -91,6 +91,9 @@ create_target_design <- function(
       } else if (targettype %in% c("auc24")) {
         offset <- 24
         when <- "dose"
+      } else if (targettype %in% c("auc12")) {
+        offset <- 12
+        when <- "dose"
       } else { # cum AUC
         when <- "dose"
       }
@@ -149,6 +152,7 @@ create_target_design <- function(
 #' - cum_auc: Cumulative AUC
 #' - auc: auc over a dosing interval
 #' - auc24: auc normalized to a 24-hour period
+#' - auc12: auc normalized to a 12-hour period
 #'
 #'
 #' @returns Returns a character vector of accepted target types.
@@ -158,7 +162,7 @@ mipd_target_types <- function() {
   c(target_types_auc, target_types_conc, target_types_time)
 }
 
-target_types_auc <- c("cum_auc", "auc", "auc24")
+target_types_auc <- c("cum_auc", "auc", "auc24", "auc12")
 target_types_time <- c("t_gt_mic","t_gt_4mic","t_gt_mic_free","t_gt_4mic_free")
 target_types_conc <- c("peak", "cmax", "cmax_1hr", "trough", "cmin", "conc")
 

--- a/R/dose_grid_search.R
+++ b/R/dose_grid_search.R
@@ -285,6 +285,9 @@ simulate_dose_interval <- function(value,
   } else if (target_design$type == "auc24") {
     # need 24 hours of dosing
     t_obs <- c(t_obs - 24, t_obs)
+  } else if (target_design$type == "auc12") {
+    # need 12 hours of dosing
+    t_obs <- c(t_obs - 12, t_obs)
   }
 
   tmp <- PKPDsim::sim(
@@ -297,7 +300,7 @@ simulate_dose_interval <- function(value,
     ...
   )
   if (is.null(pta)) {
-    if (target_design$type %in% c("auc", "auc24")) {
+    if (target_design$type %in% c("auc", "auc24", "auc12")) {
       if(!is.null(target_design$variable)) {
         return(diff(tmp[[target_design$variable]][tmp$comp == obs]))
       } else {

--- a/R/exposure_metrics.R
+++ b/R/exposure_metrics.R
@@ -111,6 +111,9 @@ calc_auc_from_regimen <- function(
   if(target_design$type == "auc24") {
     target_time <- c(target_time - 24, target_time)
   }
+  if(target_design$type == "auc12") {
+    target_time <- c(target_time - 12, target_time)
+  }
   sim_output <- PKPDsim::sim(
     model,
     parameters = parameters,

--- a/R/run_trial.R
+++ b/R/run_trial.R
@@ -35,10 +35,9 @@ run_trial <- function(
     design,
     cov_mapping,
     n_ids = NULL,
-    seed = NULL,
+    seed = 0,
     progress = TRUE
 ) {
-  if(!is.null(seed)) set.seed(seed) # important for reproducibility
 
   ## Set up data collectors
   tdms <- data.frame()
@@ -71,7 +70,9 @@ run_trial <- function(
       data[data$ID == i,],
       mapping = cov_mapping
     )
+
     # randomly draw individual PK parameters
+    set.seed(seed + i) # reset seed before each patient to ensure reproducibility
     pars_true_i <- generate_iiv(
       sim_model  = design$sim$model,
       omega      = design$sim$omega_matrix,

--- a/man/mipd_target_types.Rd
+++ b/man/mipd_target_types.Rd
@@ -20,5 +20,6 @@ types:
 \item cum_auc: Cumulative AUC
 \item auc: auc over a dosing interval
 \item auc24: auc normalized to a 24-hour period
+\item auc12: auc normalized to a 12-hour period
 }
 }

--- a/man/run_trial.Rd
+++ b/man/run_trial.Rd
@@ -4,14 +4,7 @@
 \alias{run_trial}
 \title{Run an MIPD trial}
 \usage{
-run_trial(
-  data,
-  design,
-  cov_mapping,
-  n_ids = NULL,
-  seed = NULL,
-  progress = TRUE
-)
+run_trial(data, design, cov_mapping, n_ids = NULL, seed = 0, progress = TRUE)
 }
 \arguments{
 \item{data}{data set to use for simulation, a data frame. Should contain


### PR DESCRIPTION
In a project that a PhD student in Radboud is doing, she needs to have AUC12 target for dosing of tacrolimus. Could be solved by just targeting AUC24 and multiplying targets by 2. I tried, this works, but for convenience it’s nice to have AUC12 available as well. I don’t think at this point we need to have a generic “AUCx” functionality: AUC24 is by far the most used, and AUC12 only for bi-daily dosed drugs like tacrolimus or MMF. I don’t think we’ll need a different AUCx soon.

Additionally, I noticed running her script, that the “seed” argument only ensures the first patient is the same when the simulation is run again. If in the simulation of that first patient there is a different number of calls to the random number generator (e.g. when model has different number of etas, or something in the design is different between the two runs) then the randomness is not the same anymore from that point onward, and patient two and onwards are dissimilar for the runs. We need to — at least — ensure that for each patient the same starting conditions are simulated, so need to reset the seed before each patient’s simulation is started. I propose to just use set.seed(seed + i) which seems simplest.