### PR TITLE
small bug fix for neighbouring AUCs

### DIFF
--- a/R/exposure_metrics.R
+++ b/R/exposure_metrics.R
@@ -121,7 +121,7 @@ calc_auc_from_regimen <- function(
     model,
     parameters = parameters,
     regimen = regimen,
-    t_obs = target_time_sim,
+    t_obs = unique(target_time_sim),
     iov_bins = iov[["bins"]],
     ...
   )


### PR DESCRIPTION
I wanted to run a trial with this eval design:

```r
eval_design <- create_eval_design(
  evaltype = "auc24",
  at = 1:7,
  anchor = "day"
)
```

However because the start and the end of each requested AUC bin were the same, we were ending up with duplicate observation times. 