### PR TITLE
Dose rounding

### DIFF
--- a/R/check_trial_design.R
+++ b/R/check_trial_design.R
@@ -30,8 +30,17 @@ check_trial_design <- function(design) {
     }
   }
   if(!is.null(design$regimen_update$settings)) {
-    if(any(! names(design$regimen_update$settings) %in% c("dose_resolution"))) {
-      cli::cli_abort("Not all settings provided in the regimen update design were recognized. Please revise.")
+    accepted <- c("dose_resolution")
+    df <- setdiff(names(design$regimen_update$settings), accepted)
+    if(length(df) > 0) {
+      cli::cli_abort(
+        paste0(
+          "Not all settings provided in the regimen update design were recognized: ", 
+          paste0(df, collapse = ", "),
+          ". Recognized settings: ", 
+          paste0(accepted, collapse = ",")
+        )
+      )
     }
   }
   ##  `initial_regimen$method`: same, can be passed as character or function.

--- a/R/check_trial_design.R
+++ b/R/check_trial_design.R
@@ -29,6 +29,11 @@ check_trial_design <- function(design) {
       design$regimen_update$dose_optimization_method <- get(design$regimen_update$dose_optimization_method)
     }
   }
+  if(!is.null(design$regimen_update$settings)) {
+    if(any(! names(design$regimen_update$settings) %in% c("dose_resolution"))) {
+      cli::cli_abort("Not all settings provided in the regimen update design were recognized. Please revise.")
+    }
+  }
   ##  `initial_regimen$method`: same, can be passed as character or function.
   if(inherits(design$initial_regimen$method, "character")) {
     design$initial_regimen$method <- get(design$initial_regimen$method)

--- a/R/map_adjust_dose.R
+++ b/R/map_adjust_dose.R
@@ -7,6 +7,8 @@
 #'
 #' @inheritParams simulate_fit
 #' @inheritParams dose_grid_search
+#' @param settings list of arguments to be used in dose update, e.g.
+#' `dose_resolution`.
 #' @param ... arguments passed on to PKPDmap::get_map_estimates and/or
 #'   PKPDsim::sim
 #' @returns Returns a named list: `regimen`: the updated regimen;
@@ -24,6 +26,7 @@ map_adjust_dose <- function(
     target_design,
     dose_update,
     grid = NULL,
+    settings = NULL,
     ...
 ) {
   # get MAP fit, using model for estimation
@@ -63,7 +66,7 @@ map_adjust_dose <- function(
     grid_type = "dose",
     covariates = covariates,
     iov_bins = PKPDsim::get_model_iov(est_model)$bins,
-    dose_resolution = NULL,
+    dose_resolution = settings$dose_resolution,
     ...
   )
   # return new regimen

--- a/R/map_adjust_interval.R
+++ b/R/map_adjust_interval.R
@@ -6,10 +6,8 @@
 #' interval to achieve the specified PK/PD target and updates the
 #' individual's regimen accordingly.
 #'
-#' @inheritParams simulate_fit
-#' @inheritParams dose_grid_search
-#' @param ... arguments passed on to PKPDmap::get_map_estimates and/or
-#'   PKPDsim::sim
+#' @inheritParams map_adjust_dose
+#' 
 #' @returns Returns a named list: `regimen`: the updated regimen;
 #'   `additional_info`: the MAP parameter estimates
 #' @export
@@ -24,6 +22,7 @@ map_adjust_interval <- function(
     target_design,
     dose_update,
     grid = NULL,
+    settings = NULL,
     ...
 ) {
   # get MAP fit, using model for estimation

--- a/R/model_based_starting_dose.R
+++ b/R/model_based_starting_dose.R
@@ -16,7 +16,6 @@ model_based_starting_dose <- function(
     cov_mapping,
     ...
 ) {
-
   ## Parsing and checking design specs
   reg_md <- design$initial_regimen$regimen
   interval <- reg_md$interval
@@ -64,6 +63,7 @@ model_based_starting_dose <- function(
   # convert grid to actual grid from specified seq() params
   if(!is.null(settings$dose_grid)) {
     settings$grid <- seq(settings$dose_grid[1], settings$dose_grid[2], settings$dose_grid[3])
+    settings$dose_grid <- NULL
   }
   args <- c(args, settings)
 

--- a/R/sample_and_adjust.R
+++ b/R/sample_and_adjust.R
@@ -198,6 +198,7 @@ sample_and_adjust_by_dose <- function(
       covariates = covariates
     ))
     method_args <- append(method_args, list(...))
+    method_args$dose_optimization_method <- NULL
     out <- do.call(
       regimen_update_design$dose_optimization_method,
       method_args

--- a/man/map_adjust_dose.Rd
+++ b/man/map_adjust_dose.Rd
@@ -15,6 +15,7 @@ map_adjust_dose(
   target_design,
   dose_update,
   grid = NULL,
+  settings = NULL,
   ...
 )
 }
@@ -41,6 +42,9 @@ elements for \code{prop} (proportional) and \code{add} (additive).}
 
 \item{grid}{vector specifying doses or intervals to use as test grid,
 Example: \code{seq(from = 50, to = 500, by = (500 - 50) / 10)}}
+
+\item{settings}{list of arguments to be used in dose update, e.g.
+\code{dose_resolution}.}
 
 \item{...}{arguments passed on to PKPDmap::get_map_estimates and/or
 PKPDsim::sim}

--- a/man/map_adjust_interval.Rd
+++ b/man/map_adjust_interval.Rd
@@ -16,6 +16,7 @@ map_adjust_interval(
   target_design,
   dose_update,
   grid = NULL,
+  settings = NULL,
   ...
 )
 }
@@ -42,6 +43,9 @@ elements for \code{prop} (proportional) and \code{add} (additive).}
 
 \item{grid}{vector specifying doses or intervals to use as test grid,
 Example: \code{seq(from = 50, to = 500, by = (500 - 50) / 10)}}
+
+\item{settings}{list of arguments to be used in dose update, e.g.
+\code{dose_resolution}.}
 
 \item{...}{arguments passed on to PKPDmap::get_map_estimates and/or
 PKPDsim::sim}

--- a/tests/testthat/test-check_trial_design.R
+++ b/tests/testthat/test-check_trial_design.R
@@ -83,6 +83,20 @@ test_that("check_trial_design works correctly", {
   )
   result <- check_trial_design(design_char_method)
   expect_equal(result$regimen_update$dose_optimization_method, mock_optimizer)
+
+  # Test case 8a: Unknown setting in regimen update throws an error,
+  # but known settings pass.
+  design_settings <- create_mock_design()
+  design_settings$regimen_update$settings <- list(dose_resolution = 5)
+
+  result <- check_trial_design(design_settings)
+  expect_equal(result$regimen_update$settings, list(dose_resolution = 5))
+
+  design_settings$regimen_update$settings <- list(dose_resolution = 5, unknown_arg = "bla")
+  expect_error(
+    result <- check_trial_design(design_settings),
+    "Not all settings provided in the regimen update design were recognized"
+  )
   
   # Test case 9: Character method in initial_regimen gets converted to function
   mock_method <- function(x) x

--- a/tests/testthat/test-dose_grid_search.R
+++ b/tests/testthat/test-dose_grid_search.R
@@ -21,7 +21,6 @@ test_that("trough concentration search works", {
     parameters = par,
     regimen = reg,
     refine = FALSE,
-    return_obj = FALSE,
     target_design = create_target_design(time = 72, targettype = "conc", targetvalue = 5)
   )
   #setting a probability of 50% should be the same thing
@@ -33,8 +32,6 @@ test_that("trough concentration search works", {
     omega = omega, # needs omega now!
     pta = list(prob = .5, type="gt"),
     auc_comp = 1,
-    target_time = intv * n,
-    return_obj = FALSE,
     target_design = create_target_design(time = 72, targettype = "conc", targetvalue = 5)
   )
   #setting a probability of 90% should require a higher dose
@@ -45,8 +42,6 @@ test_that("trough concentration search works", {
     regimen = reg,
     omega = omega, # needs omega now!
     pta = list(prob = .9, type="gt"),
-    target_time = intv * n,
-    return_obj = FALSE,
     target_design = create_target_design(time = 72, targettype = "conc", targetvalue = 5)
   )
   #setting a probability of 90% + ruv should require an even higher dose
@@ -58,8 +53,6 @@ test_that("trough concentration search works", {
     omega = omega, # needs omega now!
     pta = list(prob = .9, type="gt"),
     ruv = list(prop = .1, add = .5),
-    target_time = intv * n,
-    return_obj = FALSE,
     target_design= create_target_design(time = 72, targettype = "conc", targetvalue = 5)
   )
 
@@ -81,7 +74,6 @@ test_that("trough concentration search with interval optimization works", {
     parameters = par,
     regimen = reg,
     refine = FALSE,
-    return_obj = FALSE,
     verbose = T,
     target_design = create_target_design(
       at = 6,
@@ -103,8 +95,6 @@ test_that("trough concentration search with interval optimization works", {
     omega = omega, # needs omega now!
     pta = list(prob = .5, type="gt"),
     auc_comp = 1,
-    target_time = intv * n,
-    return_obj = FALSE,
     target_design = create_target_design(
       at = 6,
       targettype = "conc",
@@ -124,8 +114,6 @@ test_that("trough concentration search with interval optimization works", {
     regimen = reg,
     omega = omega, # needs omega now!
     pta = list(prob = .01, type="gt"),
-    target_time = intv * n,
-    return_obj = FALSE,
     target_design = create_target_design(
       at = 6,
       targettype = "conc",
@@ -140,12 +128,10 @@ test_that("trough concentration search with interval optimization works", {
 test_that("peak concentration search works", {
   dose_cpeak <- dose_grid_search(
     est_model = mod,
-    dose_grid = seq(from = 50, to = 300, by = (300 - 50) / 10 ),
+    grid = seq(from = 50, to = 300, by = (300 - 50) / 10 ),
     parameters = par,
     regimen = reg,
     refine = FALSE,
-    target_time = intv * (n-1) + t_inf,
-    return_obj = FALSE,
     target = create_target_design(
       targettype = "conc",
       targetvalue = 10,
@@ -165,7 +151,6 @@ test_that("AUC search works", {
     regimen = reg,
     auc_comp = 2,
     refine = FALSE,
-    target_time = 5*intv,
     target = create_target_design(
       targetvalue = 1500,
       targettype = "cum_auc",
@@ -219,7 +204,7 @@ test_that("AUC search works", {
 test_that("Probability: less than target", {
   dose_auc_prob3 <- dose_grid_search(
     est_model = mod,
-    dose_grid = seq(from = 50, to = 600, by = (500 - 50) / 10 ),
+    grid = seq(from = 50, to = 600, by = (500 - 50) / 10 ),
     parameters = par,
     regimen = reg,
     pta = list(prob = .9,
@@ -227,7 +212,6 @@ test_that("Probability: less than target", {
     auc_comp = 2,  # take AUC, not conc!
     omega = omega,
     dose_resolution = 5,
-    return_obj = FALSE,
     target = create_target_design(
       targetvalue = 1500,
       targettype = "cum_auc",
@@ -325,8 +309,7 @@ test_that("user-friendly error if no dose_grid", {
       parameters = par,
       regimen = reg,
       refine = FALSE,
-      target_design = target,
-      return_obj = FALSE
+      target_design = target
     ),
     dose_grid_error
   )
@@ -337,7 +320,6 @@ test_that("user-friendly error if no dose_grid", {
       parameters = par,
       regimen = reg,
       refine = FALSE,
-      return_obj = FALSE,
       target_design = target
     ),
     dose_grid_error
@@ -349,8 +331,6 @@ test_that("user-friendly error if no dose_grid", {
       parameters = par,
       regimen = reg,
       refine = FALSE,
-      target_time = intv * (n-1) + t_inf,
-      return_obj = FALSE,
       target_design = target
     ),
     dose_grid_error

--- a/tests/testthat/test-sample_and_adjust.R
+++ b/tests/testthat/test-sample_and_adjust.R
@@ -152,7 +152,6 @@ test_that("Can use separate models for sim and est", {
 
   # est and sim model are different
   out <- sample_and_adjust_by_dose(
-    tdm_times = c(3, 5, 8, 12, 51, 53, 56, 60),
     regimen_update_design = create_regimen_update_design(
       at = c(2, 4),
       anchor = "dose"

--- a/tests/testthat/test-sample_and_adjust.R
+++ b/tests/testthat/test-sample_and_adjust.R
@@ -343,3 +343,39 @@ test_that("TDMs below LOQ are handled correctly", {
   # if simulated TDM is below lower limit of quantification, set to half LOQ
   expect_equal(out$tdms$y[out$tdms$t == 20], 10)
 })
+
+test_that("dose rounding works", {
+  out <- sample_and_adjust_by_dose(
+    regimen_update_design = create_regimen_update_design(
+      at = c(2, 4),
+      anchor = "dose",
+      settings = list(dose_resolution = 25)
+    ),
+    sampling_design = create_sampling_design(
+      offset = c(20, 12),
+      when = c("dose", "dose"),
+      at = c(1, 3),
+      anchor = "dose"
+    ),
+    regimen = regimen,
+    pars_true_i = generate_iiv(mod, omega, par, seed = 1),
+    sim_model = mod,
+    sim_ruv = list(prop = 0.1, add = 1),
+    est_model = mod,
+    parameters = par,
+    omega = omega,
+    ruv = list(prop = 0.1, add = 1),
+    target = create_target_design(
+      targettype = "conc",
+      targetvalue = 15,
+      at = 5,
+      anchor = "dose"
+    ),
+    dose_optimization_method = map_adjust_dose
+  )
+  
+  expect_equal(
+    out$dose_updates$dose_before_update,
+    c(2000, 1225, 1175)
+  )
+})

--- a/vignettes/sample_timing.Rmd
+++ b/vignettes/sample_timing.Rmd
@@ -85,7 +85,10 @@ patient pharmacokinetics.
 update_design <- create_regimen_update_design(
   at = 5,
   anchor = "dose",
-  dose_optimization_method = map_adjust_dose
+  dose_optimization_method = map_adjust_dose,
+  settings = list(
+    dose_resolution = 50
+  )
 )
 target_design <- create_target_design(
   targettype = "auc24", 
@@ -110,11 +113,10 @@ initial_method <- create_initial_regimen_design(
   ),
   settings = list(
     auc_comp = 3,
-    dose_resolution = 250,
+    dose_resolution = 50,
     dose_grid = c(250, 5000, 250)
   )
 )
-      
 ```
 
 Now we can combine all these design choices together:
@@ -208,8 +210,11 @@ res1 <- run_trial(
   design = design1,
   cov_mapping = cov_map,
   progress = FALSE,
-  seed = 15
+  seed = 15,
+  n_ids = 3
 )
+res1$dose_updates
+
 res2 <- run_trial(
   data = dat,
   design = design2,

--- a/vignettes/sample_timing.Rmd
+++ b/vignettes/sample_timing.Rmd
@@ -203,6 +203,26 @@ variability described in the model, and residual variability will be added to
 each sample collected using the error model described in the model.
 
 ```{r}
+initial_method <- create_initial_regimen_design(
+  method = model_based_starting_dose,
+  regimen = list(
+    interval = 12,
+    type = "infusion",
+    t_inf = 1
+  ),
+  settings = list(
+    auc_comp = 3,
+    dose_resolution = 250,
+    dose_grid = c(250, 5000, 250)
+  )
+)
+design1 <- create_trial_design(
+  sampling_design = tdm_design1, # arm 1
+  target_design = target_design,
+  regimen_update_design = update_design,
+  initial_regimen_design = initial_method,
+  sim_design = model_design, est_design = model_design
+)
 res1 <- run_trial(
   data = dat,
   design = design1,

--- a/vignettes/sample_timing.Rmd
+++ b/vignettes/sample_timing.Rmd
@@ -203,26 +203,6 @@ variability described in the model, and residual variability will be added to
 each sample collected using the error model described in the model.
 
 ```{r}
-initial_method <- create_initial_regimen_design(
-  method = model_based_starting_dose,
-  regimen = list(
-    interval = 12,
-    type = "infusion",
-    t_inf = 1
-  ),
-  settings = list(
-    auc_comp = 3,
-    dose_resolution = 250,
-    dose_grid = c(250, 5000, 250)
-  )
-)
-design1 <- create_trial_design(
-  sampling_design = tdm_design1, # arm 1
-  target_design = target_design,
-  regimen_update_design = update_design,
-  initial_regimen_design = initial_method,
-  sim_design = model_design, est_design = model_design
-)
 res1 <- run_trial(
   data = dat,
   design = design1,


### PR DESCRIPTION
See issue #32 . Dose rounding was implemented only for the initial model-based dose, not for dose updates. Added now. The UI is similar to how it was implemented for initial dose, i.e. user passes a `settings` argument, with a `dose_resolution` element in there

```
update_design <- create_regimen_update_design(
  at = 5,
  anchor = "dose",
  dose_optimization_method = map_adjust_dose,
  settings = list(
    dose_resolution = 50
  )
)
```
