### PR TITLE
export final regimens; remove unnecessary check

### DIFF
--- a/R/create_target_design.R
+++ b/R/create_target_design.R
@@ -233,9 +233,7 @@ create_eval_design <- function(
         )
       }
     }
-    if (when == "unknown"){
-      stop(paste(type_eval), " is not yet supported. Please remove this metric from your evaluation.")
-    }
+
     tmp <- create_design(
       time = time,
       when = when,

--- a/R/create_target_design.R
+++ b/R/create_target_design.R
@@ -233,6 +233,10 @@ create_eval_design <- function(
         )
       }
     }
+    
+    if (isTRUE(when == "unknown")) {
+      stop(paste(type_eval), " is not yet supported. Please remove this metric from your evaluation.")
+    }
 
     tmp <- create_design(
       time = time,

--- a/R/sim_subject.R
+++ b/R/sim_subject.R
@@ -170,11 +170,17 @@ sim_subject <- function(
   if(nrow(res$gof) > 0) {
     res$gof$id <-  id
   }
+  final_reg <- as.data.frame(res$final_regimen)
+  if(isTRUE(nrow(final_reg) > 0)) {
+    final_reg$id <-  id
+  }
+  
 
   ## Return object
   list(
     tdms = res$tdms,
     dose_updates = res$dose_updates,
+    final_reg = final_reg,
     additional_info = res$additional_info,
     gof = res$gof,
     final_exposure = final_exposure,


### PR DESCRIPTION
This PR exposes the final regimens used over the course of the simulation. We already had this information compiled, and it is useful for when you want to do simulations for the final regimens but with alternative IIV values, such as to create VPCs.

I also made a check safer, since if `times` was supplied, `when` is set to be NULL.