### PR TITLE
Add predictive_ipred to collected TDMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```r
+# Load package during development
+devtools::load_all()
+
+# Run all tests
+devtools::test()
+
+# Run a single test file
+devtools::load_all(); testthat::test_file("tests/testthat/test-collect_tdms.R")
+
+# Run a specific test by name
+devtools::load_all(); testthat::test_file("tests/testthat/test-collect_tdms.R", filter = "LLOQ")
+
+# Check the package (includes R CMD check)
+devtools::check()
+
+# Regenerate documentation from roxygen comments
+devtools::document()
+```
+
+## Architecture
+
+**mipdtrial** simulates Model-Informed Precision Dosing (MIPD) trials: given a virtual patient population, it iteratively collects drug levels (TDMs), fits a PK model via MAP Bayesian estimation, and adjusts doses to hit a pharmacokinetic target (AUC, trough concentration, etc.).
+
+### Call hierarchy
+
+```
+run_trial()                          # user entry point; parallelises over subjects
+└─ sim_subject()                     # one subject
+   ├─ create_cov_object()            # data row → PKPDsim covariate list
+   ├─ initial_regimen$method()       # e.g. model_based_starting_dose()
+   └─ sample_and_adjust_by_dose()    # main dose-adjustment loop
+      ├─ collect_tdms()              # simulate drug levels + residual error
+      ├─ map_adjust_dose() / map_adjust_interval()
+      │  ├─ map_fit()                # MAP Bayesian estimation via PKPDmap
+      │  └─ dose_grid_search()       # find optimal dose/interval
+      └─ update_regimen()            # apply new dose to PKPDsim regimen
+```
+
+### The design system
+
+Everything is configured via a **trial design** object (built by `create_trial_design()`), which holds six sub-designs:
+
+| Sub-design | Key function | Controls |
+|---|---|---|
+| `sim` / `est` | `create_model_design()` | PKPDsim models and parameters for simulation ("truth") and estimation |
+| `sampling` | `create_sampling_design()` | When TDMs are collected; adaptive (peak/trough/dose-relative) or fixed times; LLOQ |
+| `target` | `create_target_design()` | PK/PD target (AUC, trough, `%T>MIC`, …); can be time-varying across updates |
+| `regimen_update` | `create_regimen_update_design()` | Which doses trigger updates; which optimisation function to use and its arguments |
+| `initial_regimen` | `create_initial_regimen_design()` | Starting dose method |
+| `evaluation` | `create_eval_design()` | Non-target metrics computed post-hoc |
+
+Trial designs can also be loaded from a YAML file via `create_trial_design(file = "spec.yaml")`.
+
+**Important:** optimization functions (e.g. `map_adjust_dose`) are **copied by value** into the design object. If you edit one of those functions you must re-run `create_regimen_update_design()` to pick up the change.
+
+### Key data structures
+
+**`tdms` data frame** (output of `collect_tdms`, accumulated in `sample_and_adjust_by_dose`):
+- `t`, `obs_type`, `true_y` – simulated truth
+- `y` – measured level (truth + residual error; LLOQ-censored if applicable)
+- `predictive_ipred` – prediction from the estimation model using current parameter estimates (population prior on dose 1, MAP estimates thereafter); `NA` when `est_design` is not supplied
+
+**`design$est` / `design$sim`** both have: `model` (PKPDsim ODE object), `parameters` (named list), `omega_matrix`, `ruv` (list with `prop`/`add`).
+
+**`run_trial()` return value** (class `mipdtrial_results`): a list of data frames — `tdms`, `dose_updates`, `final_reg`, `additional_info` (MAP estimates per update), `gof`, `final_exposure`, `eval_exposure`.
+
+### Sampling and target time anchoring
+
+`create_sampling_design()` and `create_target_design()` both accept `anchor = "dose"` or `anchor = "day"`, and `when` values such as `"dose"`, `"peak"`, `"trough"` which are resolved to absolute times at runtime by `get_sampling_times_from_scheme()`. This is why all timing-related functions receive the *current* `regimen` object — absolute times can change as doses are updated.
+
+### Separate sim/est models
+
+`sim_model` and `est_model` can differ to simulate model misspecification. True patient parameters (`pars_true_i`) must match `sim_model`; estimation uses `design$est` parameters as the population prior. Covariates must be compatible with both models.
+
+### Parallelism
+
+`run_trial()` uses `furrr::future_map()` — parallelism is controlled by the caller setting a `future` plan before calling `run_trial()`. Use `future::plan(multisession)` to enable parallel execution.
+
+## Dependencies
+
+- **PKPDsim**: ODE-based PK/PD simulation (all models, regimens, covariates)
+- **PKPDmap**: MAP Bayesian estimation (`simulate_fit`, underlying estimation engine)
+- **yaml**: YAML-based design spec loading
+- Literature model packages (e.g. `pkbusulfanmccune`) are auto-installed by tests via `PKPDsim::install_default_literature_model()` if absent

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Functions for simulating dose adjustments given PKPD models,
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests: 
     dplyr,
     ggplot2,

--- a/R/collect_tdms.R
+++ b/R/collect_tdms.R
@@ -14,8 +14,15 @@
 #' @param lloq lower limit of quantification. If non-NULL, all TDMs below LLOQ
 #'   will be set to half the LLOQ.
 #' @param ... arguments passed on to PKPDsim::sim
-#' @returns a data frame with columns `t` (time), `true_y` (actual level) and
-#'   `y` (measured level), with rows corresponding to t_obs.
+#' @param est_model model used for estimation (e.g. the model used in MAP
+#'   fitting). If provided, a predictive individual prediction is simulated
+#'   using `est_pars_i` and stored in the `predictive_ipred` column.
+#' @param est_pars_i parameters for `est_model`. Typically population or
+#'   MAP-estimated individual parameters.
+#' @returns a data frame with columns `t` (time), `true_y` (actual level),
+#'   `y` (measured level), and `predictive_ipred` (predicted level from
+#'   estimation model; `NA` if `est_model` is not supplied), with rows
+#'   corresponding to t_obs.
 #' @export
 
 collect_tdms <- function(
@@ -24,6 +31,8 @@ collect_tdms <- function(
   res_var,
   pars_i,
   lloq = NULL,
+  est_model = NULL,
+  est_pars_i = NULL,
   ...
 ) {
   if (!isTRUE(length(t_obs) == nrow(res_var))) {
@@ -47,6 +56,21 @@ collect_tdms <- function(
 
   # add residual error
   true_tdm$y <- res_var$prop * true_tdm$true_y + res_var$add
+
+  # simulate prediction from current estimation model, with current parameters (for predictive analysis)
+  # and add to tdm object as `est_y`
+  if(!is.null(est_model)) {
+    true_tdm_est <- PKPDsim::sim(
+      ode = est_model,
+      parameters = est_pars_i,
+      t_obs = t_obs,
+      only_obs = TRUE,
+      ...
+    )
+    true_tdm$predictive_ipred <- true_tdm_est$y
+  } else {
+    true_tdm$predictive_ipred <- NA
+  }
 
   # LOQ handling
   if (!is.null(lloq) && !is.na(lloq)) {

--- a/R/collect_tdms.R
+++ b/R/collect_tdms.R
@@ -57,19 +57,22 @@ collect_tdms <- function(
   # add residual error
   true_tdm$y <- res_var$prop * true_tdm$true_y + res_var$add
 
-  # simulate prediction from current estimation model, with current parameters (for predictive analysis)
-  # and add to tdm object as `est_y`
+  # simulate prediction from current estimation model, with current parameters (for 
+  # predictive analysis) and add to tdm object as `predictive_ipred`.
+  true_tdm$predictive_ipred <- NA
   if(!is.null(est_model)) {
-    true_tdm_est <- PKPDsim::sim(
-      ode = est_model,
-      parameters = est_pars_i,
-      t_obs = t_obs,
-      only_obs = TRUE,
-      ...
-    )
-    true_tdm$predictive_ipred <- true_tdm_est$y
-  } else {
-    true_tdm$predictive_ipred <- NA
+    if(is.null(est_pars_i)) {
+      cli::cli_abort("No parameters for `est_model` provided. Can't calculate `predictive_ipred`.")
+    } else {
+      true_tdm_est <- PKPDsim::sim(
+        ode = est_model,
+        parameters = est_pars_i,
+        t_obs = t_obs,
+        only_obs = TRUE,
+        ...
+      )
+      true_tdm$predictive_ipred <- true_tdm_est$y
+    }
   }
 
   # LOQ handling

--- a/R/sample_and_adjust.R
+++ b/R/sample_and_adjust.R
@@ -27,6 +27,7 @@
 #' @param accumulate_data if `TRUE`, will use all available data up until the
 #' adjustment timepoint. If set to `FALSE`, will use only the data since the
 #' last adjustment timepoint and the current one.
+#' @param est_design design specs for model used in MAP estimation (optional).
 #' @param ... arguments passed on to `simulate_fit` or dose_optimization_method
 #'   function.
 #' @param verbose verbose output?

--- a/R/sample_and_adjust.R
+++ b/R/sample_and_adjust.R
@@ -47,6 +47,7 @@ sample_and_adjust_by_dose <- function(
   sim_ruv = NULL,
   verbose = FALSE,
   accumulate_data = TRUE,
+  est_design = NULL,
   ...
 ) {
 
@@ -92,7 +93,8 @@ sample_and_adjust_by_dose <- function(
     t = numeric(0),
     obs_type = numeric(0),
     true_y = numeric(0),
-    y = numeric(0)
+    y = numeric(0),
+    predictive_ipred = numeric(0)
   )
   last_adjust_time <- 0
 
@@ -143,6 +145,11 @@ sample_and_adjust_by_dose <- function(
       target_design,
       j
     )
+    if(j == 1) {
+      est_pars_i <- est_design$parameters
+    } else {
+      est_pars_i <- out$additional_info
+    }
     new_tdms <- collect_tdms(
       sim_model = sim_model,
       t_obs = tdm_times[collect_idx],
@@ -151,7 +158,9 @@ sample_and_adjust_by_dose <- function(
       regimen = regimen,
       covariates = covariates,
       lloq = sampling_design$lloq,
-      iov_bins = iov_bins_sim
+      iov_bins = iov_bins_sim,
+      est_model = est_design$model,
+      est_pars_i = est_pars_i
     )
     auc_current_regimen <- calc_auc_from_regimen(
       regimen = regimen,

--- a/R/sim_subject.R
+++ b/R/sim_subject.R
@@ -50,6 +50,7 @@ sim_subject <- function(
     omega = design$est$omega_matrix,
     ruv = design$est$ruv,
     verbose = verbose,
+    est_design = design$est,
     # below are not formal parameters, passed onwards using ...!
     parameters = design$est$parameters,
     est_model = design$est$model

--- a/man/collect_tdms.Rd
+++ b/man/collect_tdms.Rd
@@ -4,7 +4,16 @@
 \alias{collect_tdms}
 \title{Simulate TDM collection}
 \usage{
-collect_tdms(sim_model, t_obs, res_var, pars_i, lloq = NULL, ...)
+collect_tdms(
+  sim_model,
+  t_obs,
+  res_var,
+  pars_i,
+  lloq = NULL,
+  est_model = NULL,
+  est_pars_i = NULL,
+  ...
+)
 }
 \arguments{
 \item{sim_model}{model used for simulated patient response ("truth").}
@@ -21,11 +30,20 @@ as proportional error with 0 additive error.}
 \item{lloq}{lower limit of quantification. If non-NULL, all TDMs below LLOQ
 will be set to half the LLOQ.}
 
+\item{est_model}{model used for estimation (e.g. the model used in MAP
+fitting). If provided, a predictive individual prediction is simulated
+using \code{est_pars_i} and stored in the \code{predictive_ipred} column.}
+
+\item{est_pars_i}{parameters for \code{est_model}. Typically population or
+MAP-estimated individual parameters.}
+
 \item{...}{arguments passed on to PKPDsim::sim}
 }
 \value{
-a data frame with columns \code{t} (time), \code{true_y} (actual level) and
-\code{y} (measured level), with rows corresponding to t_obs.
+a data frame with columns \code{t} (time), \code{true_y} (actual level),
+\code{y} (measured level), and \code{predictive_ipred} (predicted level from
+estimation model; \code{NA} if \code{est_model} is not supplied), with rows
+corresponding to t_obs.
 }
 \description{
 Using the "ground truth" model, simulate collection of drug/biomarker levels.

--- a/man/sample_and_adjust_by_dose.Rd
+++ b/man/sample_and_adjust_by_dose.Rd
@@ -15,6 +15,7 @@ sample_and_adjust_by_dose(
   sim_ruv = NULL,
   verbose = FALSE,
   accumulate_data = TRUE,
+  est_design = NULL,
   ...
 )
 }
@@ -44,6 +45,8 @@ proportional (\code{prop}) and additive (\code{add}) error.}
 \item{accumulate_data}{if \code{TRUE}, will use all available data up until the
 adjustment timepoint. If set to \code{FALSE}, will use only the data since the
 last adjustment timepoint and the current one.}
+
+\item{est_design}{design specs for model used in MAP estimation (optional).}
 
 \item{...}{arguments passed on to \code{simulate_fit} or dose_optimization_method
 function.}

--- a/tests/testthat/test-collect_tdms.R
+++ b/tests/testthat/test-collect_tdms.R
@@ -28,12 +28,36 @@ test_that("output structure and content are correct", {
     regimen = reg
   )
   expect_true(inherits(result, "data.frame"))
-  expect_true(all(c("t", "true_y", "y") %in% colnames(result)))
+  expect_true(all(c("t", "true_y", "y", "predictive_ipred") %in% colnames(result)))
   expect_equal(nrow(result), length(t_obs))
   expect_equal(result$t, t_obs)
   expect_equal(
     (result$y - res_var$add)/res_var$prop, result$true_y
   )
+})
+
+test_that("predictive_ipred is NA when est_model not supplied", {
+  result <- collect_tdms(mod, t_obs, res_var, pars_i, regimen = reg)
+  expect_true("predictive_ipred" %in% colnames(result))
+  expect_true(all(is.na(result$predictive_ipred)))
+})
+
+test_that("predictive_ipred is populated when est_model and est_pars_i are supplied", {
+  result <- collect_tdms(
+    mod,
+    t_obs,
+    res_var,
+    pars_i,
+    est_model = mod,
+    est_pars_i = pars_i,
+    regimen = reg
+  )
+  expect_true("predictive_ipred" %in% colnames(result))
+  expect_true(all(!is.na(result$predictive_ipred)))
+  expect_true(is.numeric(result$predictive_ipred))
+  # predictive_ipred uses est_pars_i (== pars_i here), so it should
+  # equal true_y (no residual error applied)
+  expect_equal(result$predictive_ipred, result$true_y)
 })
 
 test_that("handles LLOQ correctly", {

--- a/tests/testthat/test-sample_and_adjust.R
+++ b/tests/testthat/test-sample_and_adjust.R
@@ -344,6 +344,85 @@ test_that("TDMs below LOQ are handled correctly", {
   expect_equal(out$tdms$y[out$tdms$t == 20], 10)
 })
 
+test_that("tdms contain predictive_ipred column when est_model_design is supplied", {
+  # est_model_design is plumbed through sim_subject -> sample_and_adjust_by_dose
+  # -> collect_tdms; this test verifies the column is present and populated,
+  # and also exercises the rbind fix (tdms_i initialised with predictive_ipred).
+  est_model_design <- list(
+    model = mod,
+    parameters = par
+  )
+  out <- sample_and_adjust_by_dose(
+    regimen_update_design = create_regimen_update_design(
+      at = c(2, 4),
+      anchor = "dose"
+    ),
+    sampling_design = create_sampling_design(
+      offset = c(20, 12),
+      when = c("dose", "dose"),
+      at = c(1, 3),
+      anchor = "dose"
+    ),
+    regimen = regimen,
+    pars_true_i = list(CL = 1.5, V = 15),
+    sim_model = mod,
+    sim_ruv = list(prop = 0.1, add = 1),
+    est_model = mod,
+    parameters = par,
+    omega = omega,
+    ruv = list(prop = 0.1, add = 1),
+    target = create_target_design(
+      when = "trough",
+      at = 4,
+      anchor = "dose",
+      targettype = "conc",
+      targetvalue = 10
+    ),
+    dose_optimization_method = map_adjust_dose,
+    est_design = est_model_design
+  )
+
+  tdms <- out$tdms
+  expect_true("predictive_ipred" %in% colnames(tdms))
+  expect_true(all(!is.na(tdms$predictive_ipred)))
+  expect_true(is.numeric(tdms$predictive_ipred))
+})
+
+test_that("tdms contain predictive_ipred column (as NA) when est_model_design is NULL", {
+  out <- sample_and_adjust_by_dose(
+    regimen_update_design = create_regimen_update_design(
+      at = c(2, 4),
+      anchor = "dose"
+    ),
+    sampling_design = create_sampling_design(
+      offset = c(20, 12),
+      when = c("dose", "dose"),
+      at = c(1, 3),
+      anchor = "dose"
+    ),
+    regimen = regimen,
+    pars_true_i = list(CL = 1.5, V = 15),
+    sim_model = mod,
+    sim_ruv = list(prop = 0.1, add = 1),
+    est_model = mod,
+    parameters = par,
+    omega = omega,
+    ruv = list(prop = 0.1, add = 1),
+    target = create_target_design(
+      when = "trough",
+      at = 4,
+      anchor = "dose",
+      targettype = "conc",
+      targetvalue = 10
+    ),
+    dose_optimization_method = map_adjust_dose
+  )
+
+  tdms <- out$tdms
+  expect_true("predictive_ipred" %in% colnames(tdms))
+  expect_true(all(is.na(tdms$predictive_ipred)))
+})
+
 test_that("dose rounding works", {
   out <- sample_and_adjust_by_dose(
     regimen_update_design = create_regimen_update_design(


### PR DESCRIPTION
## Summary

- Adds `predictive_ipred` column to TDM data frames: simulates a prediction from the estimation model using the current parameter estimates (population prior on dose 1, MAP estimates on subsequent doses) and stores it alongside the observed TDMs — enabling post-hoc predictive performance analysis without changing existing behaviour.
- also adds `claude.md` file

## Test plan

- [ ] New tests in `test-collect_tdms.R`: `predictive_ipred` is `NA` when no `est_model` supplied; numeric and equal to `true_y` when same model/params used for both sim and est.
- [ ] New tests in `test-sample_and_adjust.R`: `predictive_ipred` is populated across multiple dose adjustments (exercises the rbind fix); is `NA` when `est_design` is not supplied.
- [ ] All pre-existing tests continue to pass.
