### PR TITLE
use model-appropriate IOV bins in collect_tdms

### DIFF
--- a/R/collect_tdms.R
+++ b/R/collect_tdms.R
@@ -48,6 +48,7 @@ collect_tdms <- function(
     parameters = pars_i,
     t_obs = t_obs,
     only_obs = TRUE,
+    iov_bins = PKPDsim::get_model_iov(sim_model)$bins,
     ...
   )
   # rename output for clarity/ease (PKPDmap uses `y` column for estimation)
@@ -69,6 +70,7 @@ collect_tdms <- function(
         parameters = est_pars_i,
         t_obs = t_obs,
         only_obs = TRUE,
+        iov_bins = PKPDsim::get_model_iov(est_model)$bins,
         ...
       )
       true_tdm$predictive_ipred <- true_tdm_est$y

--- a/R/sample_and_adjust.R
+++ b/R/sample_and_adjust.R
@@ -53,7 +53,6 @@ sample_and_adjust_by_dose <- function(
 ) {
 
   if (inherits(pars_true_i, "data.frame")) pars_true_i <- as.list(pars_true_i)
-  iov_bins_sim <- attr(sim_model, "iov")$bins
 
   ## Get times to adjust dose
   if(!is.null(regimen_update_design)) {
@@ -159,7 +158,6 @@ sample_and_adjust_by_dose <- function(
       regimen = regimen,
       covariates = covariates,
       lloq = sampling_design$lloq,
-      iov_bins = iov_bins_sim,
       est_model = est_design$model,
       est_pars_i = est_pars_i
     )

--- a/tests/testthat/test-collect_tdms.R
+++ b/tests/testthat/test-collect_tdms.R
@@ -72,4 +72,45 @@ test_that("handles LLOQ correctly", {
   )
 })
 
+test_that("collect_tdms uses different iov bins for sim vs est model", {
+  # Here we will mock the models and `PKPDsim::sim` since all we care about
+  # are the IOV (mis)specification. `sim_model` has 2 IOV bins and `est_model`
+  # does not have IOV bins.
+  sim_model <- structure(list(), class = "PKPDsim")
+  attr(sim_model, "iov") <- list(
+    cv = list(CL = 0.1),
+    n_bins = 2,
+    bins = c(0, 24, 9999)
+  )
+  est_model <- structure(list(), class = "PKPDsim")
+  attr(est_model, "iov") <- list(n_bins = 1) # no IOV -- bins must stay NULL
+
+  # `sim()` is called once per model. Each call must receive that model's
+  # *own* IOV bins (via `PKPDsim::get_model_iov()`), not the other model's.
+  testthat::local_mocked_bindings(
+    sim = function(ode, t_obs, iov_bins = NULL, ...) {
+      expected_bins <- attr(ode, "iov")$bins
+      # this is the check we use in PKPDsim for mismatch:
+      if (!identical(iov_bins, expected_bins)) {
+        stop("iov_bins passed to sim() do not match the model's own IOV spec")
+      }
+      # return dummy data:
+      data.frame(t = t_obs, obs_type = 1, y = seq_along(t_obs))
+    },
+    .package = "PKPDsim"
+  )
+
+  expect_no_error(
+    result <- collect_tdms(
+      sim_model = sim_model,
+      t_obs = c(1, 2),
+      res_var = data.frame(prop = c(0.1, 0.1), add = c(1, 1)),
+      pars_i = list(CL = 1),
+      est_model = est_model,
+      est_pars_i = list(CL = 1)
+    )
+  )
+  expect_true(all(!is.na(result$predictive_ipred)))
+})
+
 


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/InsightRX/mipdtrial/pull/40.

Briefly, it is possible for sim_model and est_model to have different IOV specifications. We were accidentally using the same iov_bins for both models, passed onto `PKPDsim::sim` from `sample_and_adjust` using the `...` args.

`collect_tdms` now relies directly on the attributes of each respective model for the iov_bins argument, since this seemed like the cleanest and most robust approach. 

unit test uses mocking to avoid having to fuss around with loading two mismatched models.